### PR TITLE
Issue 33: duplicate data definitions

### DIFF
--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/SymbolTable.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/SymbolTable.kt
@@ -50,7 +50,7 @@ class SymbolTable {
 
     operator fun set(data: AbstractDataDefinition, value: Value) {
         require(!(data !in this && data.name in this)) {
-            "This data definition would conflict with an existing data definition with the same name"
+            "This data definition would conflict with an existing data definition with the same name. This data definition: $data. Existing data definition: ${this[data.name]}"
         }
         values[data] = value
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/SymbolTable.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/SymbolTable.kt
@@ -6,6 +6,7 @@ class SymbolTable {
     private val values = LinkedHashMap<AbstractDataDefinition, Value>()
 
     operator fun contains(dataName: String): Boolean = dataDefinitionByName(dataName) != null
+    operator fun contains(data: AbstractDataDefinition): Boolean = data in values
 
     operator fun get(data: AbstractDataDefinition): Value {
         if (data is FieldDefinition) {
@@ -48,6 +49,9 @@ class SymbolTable {
             values.keys.firstOrNull { it.name.equals(dataName, ignoreCase = true) }
 
     operator fun set(data: AbstractDataDefinition, value: Value) {
+        require(!(data !in this && data.name in this)) {
+            "This data definition would conflict with an existing data definition with the same name"
+        }
         values[data] = value
     }
 }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/interpreter/data_definitions.kt
@@ -182,7 +182,11 @@ class InStatementDataDefinition(
     override val type: Type,
     override val position: Position? = null,
     val initializationValue: Expression? = null
-) : AbstractDataDefinition(name, type, position)
+) : AbstractDataDefinition(name, type, position) {
+    override fun toString(): String {
+        return "InStatementDataDefinition name=$name, type=$type, position=$position"
+    }
+}
 
 /**
  * Encoding/Decoding a binary value for a data structure

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/cu_components.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/cu_components.kt
@@ -58,21 +58,23 @@ data class CompilationUnit(
                     }
                 }
                 _allDataDefinitions.addAll(inStatementsDataDefinitions)
-                checkDuplicatedDataDefinition(_allDataDefinitions)
+                _allDataDefinitions = checkDuplicatedDataDefinition(_allDataDefinitions).toMutableList()
             }
             return _allDataDefinitions
         }
 
-    private fun checkDuplicatedDataDefinition(dataDefinitions: List<AbstractDataDefinition>) {
+    private fun checkDuplicatedDataDefinition(dataDefinitions: List<AbstractDataDefinition>) : List<AbstractDataDefinition> {
         val dataDefinitionMap = mutableMapOf<String, AbstractDataDefinition>()
-        dataDefinitions.forEach {
+        return dataDefinitions.filter {
             val dataDefinition = dataDefinitionMap[it.name]
             if (dataDefinition == null) {
                 dataDefinitionMap[it.name] = it
+                true
             } else {
                 require(dataDefinition.type == it.type) {
                     "Incongruous definitions of ${it.name}: ${dataDefinition.type} vs ${it.type}"
                 }
+                false
             }
         }
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/cu_components.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/cu_components.kt
@@ -63,7 +63,7 @@ data class CompilationUnit(
             return _allDataDefinitions
         }
 
-    private fun checkDuplicatedDataDefinition(dataDefinitions: List<AbstractDataDefinition>) : List<AbstractDataDefinition> {
+    private fun checkDuplicatedDataDefinition(dataDefinitions: List<AbstractDataDefinition>): List<AbstractDataDefinition> {
         val dataDefinitionMap = mutableMapOf<String, AbstractDataDefinition>()
         return dataDefinitions.filter {
             val dataDefinition = dataDefinitionMap[it.name]

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -210,6 +210,8 @@ data class PlistStmt(
 ) : Statement(position), StatementThatCanDefineData {
     override fun dataDefinition(): List<InStatementDataDefinition> {
         val allDataDefinitions = params.mapNotNull { it.dataDefinition }
+        // We do not want params in plist to shadow existing data definitions
+        // They are implicit data definitions only when explicit data definitions are not present
         val filtered = allDataDefinitions.filter {paramDataDef ->
             val containingCU = this.ancestor(CompilationUnit::class.java) ?: throw IllegalStateException("Not contained in a CU")
             containingCU!!.dataDefinitions.none { it.name == paramDataDef.name}

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -214,7 +214,7 @@ data class PlistStmt(
         // They are implicit data definitions only when explicit data definitions are not present
         val filtered = allDataDefinitions.filter { paramDataDef ->
             val containingCU = this.ancestor(CompilationUnit::class.java) ?: throw IllegalStateException("Not contained in a CU")
-            containingCU!!.dataDefinitions.none { it.name == paramDataDef.name }
+            containingCU.dataDefinitions.none { it.name == paramDataDef.name }
         }
         return filtered
     }

--- a/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
+++ b/rpgJavaInterpreter-core/src/main/kotlin/com/smeup/rpgparser/parsing/ast/statements.kt
@@ -212,9 +212,9 @@ data class PlistStmt(
         val allDataDefinitions = params.mapNotNull { it.dataDefinition }
         // We do not want params in plist to shadow existing data definitions
         // They are implicit data definitions only when explicit data definitions are not present
-        val filtered = allDataDefinitions.filter {paramDataDef ->
+        val filtered = allDataDefinitions.filter { paramDataDef ->
             val containingCU = this.ancestor(CompilationUnit::class.java) ?: throw IllegalStateException("Not contained in a CU")
-            containingCU!!.dataDefinitions.none { it.name == paramDataDef.name}
+            containingCU!!.dataDefinitions.none { it.name == paramDataDef.name }
         }
         return filtered
     }

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/StatementsTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/StatementsTest.kt
@@ -8,7 +8,6 @@ import com.smeup.rpgparser.parsing.parsetreetoast.resolve
 import com.smeup.rpgparser.parsing.parsetreetoast.toAst
 import com.strumenta.kolasu.model.ReferenceByName
 import com.strumenta.kolasu.model.collectByType
-import com.strumenta.kolasu.model.find
 import org.junit.Ignore
 import kotlin.test.assertEquals
 import org.junit.Test as test

--- a/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/StatementsTest.kt
+++ b/rpgJavaInterpreter-core/src/test/kotlin/com/smeup/rpgparser/parsing/ast/StatementsTest.kt
@@ -4,8 +4,11 @@ import com.smeup.rpgparser.*
 import com.smeup.rpgparser.parsing.ast.DataWrapUpChoice.LR
 import com.smeup.rpgparser.parsing.ast.DataWrapUpChoice.RT
 import com.smeup.rpgparser.parsing.parsetreetoast.ToAstConfiguration
+import com.smeup.rpgparser.parsing.parsetreetoast.resolve
 import com.smeup.rpgparser.parsing.parsetreetoast.toAst
 import com.strumenta.kolasu.model.ReferenceByName
+import com.strumenta.kolasu.model.collectByType
+import com.strumenta.kolasu.model.find
 import org.junit.Ignore
 import kotlin.test.assertEquals
 import org.junit.Test as test
@@ -239,5 +242,21 @@ class StatementsTest {
 
     @test fun parseEvalWithGlobalIndicatorTarget() {
         assertStatementCanBeParsed("EVAL      *IN=*ON", addPrefix = true)
+    }
+
+    @test fun plistDeclareVariable() {
+        val cu = assertASTCanBeProduced("ECHO")
+        cu.resolve()
+        val plists = cu.collectByType(PlistStmt::class.java).distinct()
+        assertEquals(1, plists.size)
+        assertEquals(1, plists.first().dataDefinition().size)
+    }
+
+    @test fun plistDoesNotDeclareVariable() {
+        val cu = assertASTCanBeProduced("ECHO2")
+        cu.resolve()
+        val plists = cu.collectByType(PlistStmt::class.java).distinct()
+        assertEquals(1, plists.size)
+        assertEquals(0, plists.first().dataDefinition().size)
     }
 }


### PR DESCRIPTION
@f-lombardo this should fix what we discussed in the meeting today. The fact is that certain statements (e.g., PARM in PLIST) define data, only if an existing data definition with the same name is not present. We check that and remove the duplicate data definition.

We try to add a few checks in different places for robustness.

Fix #33 